### PR TITLE
Fix issue where duplicate cut pieces cause a subtract overflow error.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -690,7 +690,9 @@ where
                 } else {
                     // We're keeping this bin so decrement the quantity of the available stock
                     // piece.
-                    stock_piece.dec_quantity();
+                    if stock_piece.quantity != Some(0) {
+                        stock_piece.dec_quantity();
+                    }
                 }
             } else {
                 // There's no available stock piece left for this bin so remove it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -675,7 +675,7 @@ where
             if let Some(ref mut stock_piece) = new_unit
                 .available_stock_pieces
                 .iter_mut()
-                .find(|sp| bin.matches_stock_piece(sp))
+                .find(|sp| sp.quantity != Some(0) && bin.matches_stock_piece(sp))
             {
                 // We found an available stock piece for this bin, so attempt to use it.
                 let injected_cut_pieces = (&other.bins[cross_src_start..cross_src_end])
@@ -690,9 +690,7 @@ where
                 } else {
                     // We're keeping this bin so decrement the quantity of the available stock
                     // piece.
-                    if stock_piece.quantity != Some(0) {
-                        stock_piece.dec_quantity();
-                    }
+                    stock_piece.dec_quantity();
                 }
             } else {
                 // There's no available stock piece left for this bin so remove it.

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -615,6 +615,45 @@ fn guillotine_one_stock_piece_several_cut_pieces() {
 }
 
 #[test]
+fn guillotine_stock_duplicate_cut_piece() {
+    let solution = Optimizer::new()
+        .add_stock_piece(StockPiece {
+            width: 48,
+            length: 96,
+            pattern_direction: PatternDirection::None,
+            price: 0,
+            quantity: Some(1),
+        })
+        .add_stock_piece(StockPiece {
+            width: 64,
+            length: 192,
+            pattern_direction: PatternDirection::None,
+            price: 0,
+            quantity: Some(1),
+        })
+        .add_cut_piece(CutPiece {
+            external_id: None,
+            width: 48,
+            length: 96,
+            pattern_direction: PatternDirection::None,
+            can_rotate: false,
+        })
+        .add_cut_piece(CutPiece {
+            external_id: None,
+            width: 48,
+            length: 96,
+            pattern_direction: PatternDirection::None,
+            can_rotate: false,
+        })
+        .set_cut_width(1)
+        .set_random_seed(1)
+        .optimize_guillotine(|_| {})
+        .unwrap();
+
+    sanity_check_solution(&solution, 2);
+}
+
+#[test]
 fn guillotine_32_cut_pieces_on_1_stock_piece() {
     let mut optimizer = Optimizer::new();
     optimizer.add_stock_piece(StockPiece {


### PR DESCRIPTION
Found another bug where identical cut pieces cause a subtract overflow error. You can run the test without the lib.rs change to see the problem in action. I'm not sure exactly what's going on but when I debug somehow cut_piece.quantity can reach Some(0) and still iterate.

This is the error:
`
attempt to subtract with overflow
thread 'tests::guillotine_stock_duplicate_cut_piece' panicked at 'attempt to subtract with overflow', src/lib.rs:242:13
`